### PR TITLE
Added sensor 0x93 - Next MCW

### DIFF
--- a/custom_components/visonic/pyvisonic.py
+++ b/custom_components/visonic/pyvisonic.py
@@ -1071,6 +1071,7 @@ pmZoneSensorMax_t = {
    0x7A : ZoneSensorType("MCT-550", AlSensorType.FLOOD ),          # fguerzoni, Joao-Sousa
    0x86 : ZoneSensorType("MCT-302", AlSensorType.MAGNET ),         # Joao-Sousa
    0x8A : ZoneSensorType("MCT-550", AlSensorType.FLOOD ),          # Joao-Sousa
+   0x93 : ZoneSensorType("Next MCW", AlSensorType.MOTION ),        # Tomas-Corral
    0x95 : ZoneSensorType("MCT-302", AlSensorType.MAGNET ),         # me, fguerzoni
    0x96 : ZoneSensorType("MCT-302", AlSensorType.MAGNET ),         # me, g4seb, rogerthn2019
    0x97 : ZoneSensorType("MCT-302", AlSensorType.MAGNET ),         # christopheVia


### PR DESCRIPTION
One of my sensors was not identified, VisonicSensorRef is 0x93.
I tested in my panel and it is now displaying correctly.

The sensor is this one:
![Next_MCW](https://github.com/user-attachments/assets/a8c59775-3473-4747-a55c-fb058f9dd558)


Also the code for printing the sensor types is commented, even with the debug enabled it won't show.
The log message "[Process Settings] Found unknown sensor type ..." did not show to me when I had an unknown sensor, I think the code is not reaching that part.