### PR TITLE
ADDED Glass Break Sensor 

### DIFF
--- a/custom_components/visonic/binary_sensor.py
+++ b/custom_components/visonic/binary_sensor.py
@@ -37,7 +37,8 @@ _stype_to_ha_sensor_class = {
     AlSensorType.VIBRATION   : BinarySensorDeviceClass.VIBRATION, 
     AlSensorType.SHOCK       : BinarySensorDeviceClass.VIBRATION,
     AlSensorType.TEMPERATURE : BinarySensorDeviceClass.HEAT,
-    AlSensorType.SOUND       : BinarySensorDeviceClass.SOUND
+    AlSensorType.SOUND       : BinarySensorDeviceClass.SOUND,
+    AlSensorType.GLASS_BREAK : BinarySensorDeviceClass.VIBRATION,
 }
 
 

--- a/custom_components/visonic/pyconst.py
+++ b/custom_components/visonic/pyconst.py
@@ -280,7 +280,8 @@ class AlSensorType(AlEnum):
     VIBRATION = AlIntEnum(7)
     SHOCK = AlIntEnum(8)
     TEMPERATURE = AlIntEnum(9)
-    SOUND = AlIntEnum(10)
+    SOUND = AlIntEnum(10),
+    GLASS_BREAK = AlIntEnum(11),
 a = AlSensorType()
 
 class AlLogPanelEvent:

--- a/custom_components/visonic/pyconst.py
+++ b/custom_components/visonic/pyconst.py
@@ -280,8 +280,8 @@ class AlSensorType(AlEnum):
     VIBRATION = AlIntEnum(7)
     SHOCK = AlIntEnum(8)
     TEMPERATURE = AlIntEnum(9)
-    SOUND = AlIntEnum(10),
-    GLASS_BREAK = AlIntEnum(11),
+    SOUND = AlIntEnum(10)
+    GLASS_BREAK = AlIntEnum(11)
 a = AlSensorType()
 
 class AlLogPanelEvent:

--- a/custom_components/visonic/pyvisonic.py
+++ b/custom_components/visonic/pyvisonic.py
@@ -1123,7 +1123,8 @@ pmZoneSensorMaster_t = {
    0x2C : ZoneSensorType("MC-303V PG2", AlSensorType.MAGNET),
    0x2D : ZoneSensorType("MC-302V PG2", AlSensorType.MAGNET),
    0x35 : ZoneSensorType("SD-304 PG2", AlSensorType.SHOCK),
-   0xFE : ZoneSensorType("Wired", AlSensorType.WIRED )
+   0x0B : ZoneSensorType("GB-502 PG2", AlSensorType.GLASS_BREAK),
+   0xFE : ZoneSensorType("Wired", AlSensorType.WIRED)
 }
 
 ##############################################################################################################################################################################################################################################


### PR DESCRIPTION
- I've got a Powermaster 10 and a Powermax Express panel with various sensors. I've noticed the glass break sensor isn't included so I've added this in.
- This has been set as Vibration in the BinarySensor configuration
- Tested using the following device: USR-TCP232-E2