### PR TITLE
Fix DataUpdateCoordinator missing logger argument on HA Core 2026.8+

### DIFF
--- a/custom_components/visonic/coordinator_base.py
+++ b/custom_components/visonic/coordinator_base.py
@@ -82,6 +82,7 @@ class VisonicCoordinator(DataUpdateCoordinator[VisonicCoordinatorData]):
         super().__init__(
             hass,
             #logger=_COORDINATOR_LOGGER,
+            logging.getLogger(__name__),
             name=f"{capitalize(DOMAIN)} {entry.title}",
             config_entry=entry,
             update_interval=timedelta(seconds=update_interval),


### PR DESCRIPTION
### Description
Home Assistant Core 2026.8 strictly requires `logger` as a positional argument in `DataUpdateCoordinator.__init__()`. Without it, setting up the entry raises a `TypeError`.

### Error Log Fixed
` TypeError: DataUpdateCoordinator.__init__() missing 1 required positional argument: 'logger' ` 

### Changes
- Passed `logging.getLogger(__name__)` as the second positional argument to `super().__init__()` in `coordinator_base.py`.

Tested on Home Assistant Core 2026.8.2 with `0.13.0.24` pre-release (Ethernet config (wi-fi) via NodeMCU/esp-link).