### PR TITLE
Fix false triggered state on arm_home/arm_away

### DIFF
--- a/custom_components/visonic/direct/pyvisonic/py_partition_state.py
+++ b/custom_components/visonic/direct/pyvisonic/py_partition_state.py
@@ -188,6 +188,8 @@ class PartitionStateClass:
         self.PanelTroubleStatus: AlTroubleType = AlTroubleType.NONE
         self.PartitionGeneralTrouble: bool = False
         self.PanelBatteryTrouble: bool = False
+        self.WasEntryDelay: bool = False           # real entry-delay countdown seen this arm cycle
+        self.PanelIntruderConfirmed: bool = False  # PanelIntruderStatus set by a real zone breach, not just ALARM_DELAY
 
     def shutdownOperation(self):
         """Shutdown operation."""
@@ -322,8 +324,11 @@ class PartitionStateClass:
         #self.PanelIntruderStatus = bool(et in pmPanelIntruderType_t)
         if et in pmPanelIntruderType_t:
             self.PanelIntruderStatus = True      # event in trigger set
+            if et != EventType.ALARM_DELAY:
+                self.PanelIntruderConfirmed = True   # unambiguous zone breach
         if et in pmPanelIntruderType_r:
             self.PanelIntruderStatus = False     # event in restore set
+            self.PanelIntruderConfirmed = False
 
         # Update alarm status
         #self.PanelAlarmStatus = pmPanelAlarmType_t[et] if et in pmPanelAlarmType_t else AlAlarmType.NONE
@@ -364,7 +369,8 @@ class PartitionStateClass:
         elif self.PanelStateSourceData is not None and self.PanelIntruderStatus:
             armed = pmPanelArmedStatus[self.PanelStateSourceData].armed
             entry = pmPanelArmedStatus[self.PanelStateSourceData].entry
-            if armed is not None and armed and not entry:
+            # ALARM_DELAY alone also fires harmlessly when exit delay ends, so require confirmation for it
+            if armed is not None and armed and not entry and (self.PanelIntruderConfirmed or self.WasEntryDelay):
                 self.SirenActive = True
                 self.SirenActiveDeviceTrigger = None if sensor is None else sensor
                 self.startIntruderTimer()
@@ -420,6 +426,9 @@ class PartitionStateClass:
             self.PanelStateData = AlPanelStatus.UNKNOWN  # UNKNOWN
             self.PanelStateSourceData = None
 
+        if entry:
+            self.WasEntryDelay = True
+
         if PanelMode == AlPanelMode.DOWNLOAD:
             self.PanelStateData = AlPanelStatus.DOWNLOADING  # Downloading
             self.PanelStateSourceData = None
@@ -472,6 +481,8 @@ class PartitionStateClass:
                 log.debug("[UpdatePartition] ******************** Alarm Not Sounding (Disarmed) ****************")
                 self.SirenActive = False
                 self.SirenActiveDeviceTrigger = None
-                self.PanelIntruderStatus = False
+            self.PanelIntruderStatus = False
+            self.WasEntryDelay = False
+            self.PanelIntruderConfirmed = False
 
         return retval


### PR DESCRIPTION
## Problem

`alarm_control_panel` reports state `triggered` immediately after a normal `arm_home` or `arm_away`, even though the physical panel never sounds and no zone was breached. It reproduces on almost every arm cycle. Confirmed on a PowerMaster 30 in Powerlink mode, integration version 0.13.0.30 (`dev` branch, commit `ee67a55`).

## Root cause

When the exit delay finishes and the panel reports `ARMED_HOME`/`ARMED_AWAY` (`sysStatus` `0x04`/`0x05`), it also logs a `Delay Alarm` event (`EventType.ALARM_DELAY = 0x03`) for the entry/exit zone. This is the panel's routine "exit delay just ended" notice, not an intruder event.

`ALARM_DELAY` is in `pmPanelIntruderType_t` in `py_partition_state.py`, so it unconditionally sets `PanelIntruderStatus = True`. `UpdatePanelState()`'s escalation branch then promotes this straight to `SirenActive = True` (i.e. `triggered`), because the partition is already `armed` and not in `entry` delay — which is also true the instant a normal arm completes.

The same `Delay Alarm` event fires for two situations the code cannot currently tell apart:
1. A real entry-delay countdown expiring after someone opens a door while armed — a genuine intruder condition, should escalate.
2. The routine end of exit delay as arming finishes — benign, happens on every arm.

## Fix

Track two extra bits of state on `PartitionStateClass`:
- `WasEntryDelay` — set when a genuine entry-delay period (`sysStatus` `0x03`/`0x13`) is actually seen during the current arm cycle, cleared on disarm.
- `PanelIntruderConfirmed` — set only when `PanelIntruderStatus` was raised by an unambiguous zone-breach event (`ALARM_INTERIOR`/`ALARM_PERIMETER`/`ALARM_SILENT_24H`/`ALARM_AUDIBLE_24H`), not by `ALARM_DELAY` alone.

The escalation check in `UpdatePanelState()` now only promotes an `ALARM_DELAY`-only trigger to `SirenActive` when a real entry delay was actually seen this cycle. The four unambiguous event types are untouched and still escalate immediately, so a genuine intrusion while already armed (no entry delay involved, e.g. a window breaks) is unaffected.

While testing I also found `PanelIntruderStatus` (and so the `alarm` state attribute) only got reset on disarm when `SirenActive` had actually gone `True`. On a disarm following one of these benign `ALARM_DELAY` events, that left the `alarm` attribute stuck at `intruder` indefinitely even though nothing was ever triggered — this was in fact my first clue while diagnosing the issue live: the panel currently shows `state: disarmed` with `alarm: intruder`. Moved the `PanelIntruderStatus` (and new flags) reset out from under the `if self.SirenActive:` guard so a disarm always clears it, whether or not it escalated.

## Testing

Reproduced and fixed live via the Home Assistant REST API against the real panel, with `custom_components.visonic` set to `debug`.

**Before the fix** — arms, then false-triggers within a second of `ARMED_HOME`:
```
2026-08-18 08:43:38.058 [UpdatePartition]  sysStatus=0x4  log: ARMED_HOME, disarmed=False  armed=True
2026-08-18 08:43:38.368 [UpdatePanelState] ******************** Intruder Active *******************
2026-08-18 08:43:38.368 [UpdatePanelState] event_type=3 False none 2 True True True
2026-08-18 08:43:38.427 [visonic]  P0  Siren Active (Intruder)
2026-08-18 08:43:38.453 [visonic]  P0  Siren Active (Intruder)
... (repeats for several seconds)
```
HA state history for that window: `armed_home` → `triggered` within 0.3s, `alarm_control_panel` attribute `alarm: intruder`.

**After the fix** — same arm sequence, same `ALARM_DELAY` (`event_type=3`) event and the panel's own `ARMED_HOME` confirmation (`event_type=81`) moments later, neither escalates:
```
2026-08-18 09:16:53.015 [UpdatePartition]  sysStatus=0x4  log: ARMED_HOME, disarmed=False  armed=True
2026-08-18 09:16:53.155 [UpdatePanelState] event_type=3 False none 2 False True True
2026-08-18 09:16:53.393 [UpdatePartition]  sysStatus=0x4  log: ARMED_HOME, disarmed=False  armed=True
2026-08-18 09:16:53.562 [UpdatePanelState] event_type=81 False none 2 False True True
2026-08-18 09:16:54.181 [UpdatePartition]  sysStatus=0x4  log: ARMED_HOME, disarmed=False  armed=True
```
(`SirenActive` is the 4th field after `event_type=N`: `True` before the fix, `False` after, for both events.) `alarm_control_panel` state stayed `armed_home` for the full test. Disarming afterwards now correctly reports `state: disarmed, alarm: none` — before this fix that stayed stuck at `alarm: intruder` even without ever escalating to `triggered`. A repeat arm cycle behaved the same way both times.

Also note an earlier attempt at this fix only excluded escalation when the *current* event was `ALARM_DELAY`. That missed a second call to `UpdatePanelState()` moments later carrying the panel's own `ARMED_HOME` confirmation event (`event_type=81`), which still saw `PanelIntruderStatus` latched `True` from the `ALARM_DELAY` call and escalated anyway. `PanelIntruderConfirmed` fixes that by tracking *why* the flag is set rather than gating on whichever event happens to be processed at escalation time.

Also tested `arm_home_instant` (via the integration's own `alarm_panel_command` service, `command: arm_home_instant`) since instant arm modes take a different `sysStatus` path (`0x11` → `0x14 ARMED_HOME_INSTANT`, not `0x04`). Same benign `ALARM_DELAY` fires at the same point, `SirenActive` stays `False` the same way — the fix generalises to instant arm without any special-casing, since it only depends on `entry`/`armed` from `pmPanelArmedStatus`, which instant statuses populate the same way.

## Other escalation paths

Two real-intrusion paths run through this same code and are worth spelling out, since only one of them was live-tested:

**A real break-in through a different, non-delay zone during exit delay** (e.g. a window breaks while you're still walking out to arm away). Unaffected by this change: `ALARM_INTERIOR`/`ALARM_PERIMETER`/`ALARM_SILENT_24H`/`ALARM_AUDIBLE_24H` set `PanelIntruderConfirmed` unconditionally and still escalate the instant they're reported, regardless of `WasEntryDelay` or exit/entry state — same as before this change, and before the regression.

**A real break-in via a delay zone that isn't disarmed before the entry-delay countdown expires.** `WasEntryDelay` is set the moment the real countdown *starts* (`sysStatus` `0x03`/`0x13`), not at expiry, so it's already `True` well before the delay can run out. If it does run out, the panel's next `ARMED_HOME`/`ARMED_AWAY` plus alarm event still escalates via `WasEntryDelay`, exactly as before this change.
