### PR TITLE
Fix sensor bypass: treat an empty code as no code supplied

### DIFF
--- a/custom_components/visonic/cloud/coordinator_cloud.py
+++ b/custom_components/visonic/cloud/coordinator_cloud.py
@@ -305,7 +305,7 @@ class VisonicCloudCoordinator(VisonicCoordinator):
 
     def get_panel_pin_code(self, code: str | None) -> tuple[bool, str]:
         """Get code code."""
-        if code is None or (PIN_REGEX.match(code) and code == self.cloud_alarm.get_user_code()):
+        if not code or (PIN_REGEX.match(code) and code == self.cloud_alarm.get_user_code()):
             return True, self.cloud_alarm.get_user_code()
         return False, None
 

--- a/custom_components/visonic/coordinator_base.py
+++ b/custom_components/visonic/coordinator_base.py
@@ -484,7 +484,7 @@ class VisonicCoordinator(DataUpdateCoordinator[VisonicCoordinatorData]):
                 )
             for s in sl:
                 self._event_logger.logstate_debug(f"Attempting to bypass sensor: {s}")
-                status: CommandResult = await self.send_bypass(s, True)
+                status: CommandResult = await self.send_bypass(s, True, None)
                 if status != AlarmCommandStatus.SUCCESS:
                     return CommandResult(
                         status.status,

--- a/custom_components/visonic/direct/coordinator_direct.py
+++ b/custom_components/visonic/direct/coordinator_direct.py
@@ -305,7 +305,7 @@ class VisonicDirectCoordinator(VisonicCoordinator):
 
     def get_panel_pin_code(self, code: str | None):
         """Get code."""
-        if code is not None:
+        if code:
             if isinstance(code, str) and PIN_REGEX.match(code):
                 # code has been provide and it validates
                 return True, code


### PR DESCRIPTION
### The problem

On a PowerMaster 30 over a powerlink (direct) connection, bypassing a sensor never reaches the panel. Every attempt returns:

```
[select_option] Command bypass not sent to panel CommandResult(
    status=<AlarmCommandStatus.FAIL_INVALID_CODE: 3>,
    notify=<AvailableNotifications.INVALID_PIN: 'invalid_pin'>,
    message='Invalid pin', did_bypass=False)
```

The user never sees it, because `invalid_pin` is not in the default `panel_state_notifications` set, so it is logged as "not shown in frontend" and the select silently reverts to `armed`.

### Cause

`select.async_select_option` sends an empty string rather than `None`:

```python
result = await self.coordinator.send_bypass(self._sensor_id, option == BYPASS, "")
```

`VisonicDirectCoordinator.get_panel_pin_code` then treats that empty string as a supplied code:

```python
if code is not None:          # "" is not None
    if isinstance(code, str) and PIN_REGEX.match(code):   # "" fails
        return True, code
    return False, None        # returns here
if self._client.achieved_powerlink():
    return True, None         # never reached
```

So the powerlink branch, which is exactly the case where the lower layer already holds the code, is unreachable from the select entity. `alarm_sensor_bypass` is affected the same way: `services.yaml` gives its `code` field `default: ""`, so calling the service without a code fails identically.

`VisonicCloudCoordinator.get_panel_pin_code` has the same shape (`if code is None or (PIN_REGEX.match(code) and ...)`), so an empty string fails there too.

### Also fixed

`_command_bypass_on_open_zones` calls `send_bypass` with two of its three arguments:

```python
status: CommandResult = await self.send_bypass(s, True)
```

`send_bypass(self, devid, bypass, code)` has no default for `code`, so this raises `TypeError` on the arm-with-bypass path. No code is in scope there or in its caller `bypass_open_zones`, so it passes `None`, which with the first fix resolves correctly via powerlink.

### The change

Three one-line changes, treating a blank code as "not supplied" rather than as an invalid code.

### Testing

Against a PowerMaster 30, powerlink, 0.13.0.42. Before the change every bypass returned `FAIL_INVALID_CODE`. After it, the panel confirms:

```
Zone Bypass 32-01 : 00000000000000000000000000010000
Sending HA Event visonic_alarm_panel_state {'name': 'Zone 05', 'event': 'Bypass'}
select.<sensor>_arm_mode -> bypass
```

Setting it back to `armed` works too. The cloud and arm-with-bypass changes are by inspection; I have no cloud panel to test against.

### Note on 0.13.0.39

Worth mentioning in case others hit it: in 0.13.0.39 `send_bypass` also called `get_panel_and_partition_state(PARTITION_ID_WHEN_BASE)` while the base declared `(self, partition, show_keypad)`, so bypass raised `TypeError` and returned HTTP 500. That one is already fixed in 0.13.0.42.
